### PR TITLE
fix: add inadvertently removed methods getListenIp and getListenPort

### DIFF
--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -300,4 +300,20 @@ class Proxy implements JsonSerializable
                 );
         }
     }
+
+    public function getListenIp(): string
+    {
+        $ip = implode(':', explode(':', $this->listen, -1));
+        if (str_starts_with($ip, '[')) {
+            $ip = substr($ip, 1, -1);
+        }
+        return $ip;
+    }
+
+    public function getListenPort(): string
+    {
+        $ip = $this->getListenIp();
+        $start = str_starts_with($this->listen, '[') ? 3 : 1;
+        return substr($this->listen, $start + strlen($ip));
+    }
 }

--- a/tests/ProxyTest.php
+++ b/tests/ProxyTest.php
@@ -234,4 +234,20 @@ class ProxyTest extends BaseTestCase
         $proxy = new Proxy($toxiproxy, '');
         $proxy->delete(new Toxic($proxy, '', '', ''));
     }
+
+    public function testGetListenIp(): void
+    {
+        $toxiproxy = $this->createToxiproxy();
+        $proxy = $this->createProxy($toxiproxy);
+        $listenIp = $proxy->getListenIp();
+        self::assertNotEmpty($listenIp);
+    }
+
+    public function testGetListenPort(): void
+    {
+        $toxiproxy = $this->createToxiproxy();
+        $proxy = $this->createProxy($toxiproxy);
+        $listenPort = $proxy->getListenPort();
+        self::assertNotEmpty($listenPort);
+    }
 }


### PR DESCRIPTION
these used to be in src/ListenHelpers.php trait and I mistakenly removed them because I didn't realize they were part of the public interface